### PR TITLE
adding support of url match against pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 *.py[co]
+
+dist

--- a/.idea/django-advanced-redirects.iml
+++ b/.idea/django-advanced-redirects.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/advanced_redirects" isTestSource="false" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 2.7.5 virtualenv at ~/.virtualenvs/automobile-web" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7.8 virtualenv at C:\Users\Evgeniy\.env\automobile" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7.5 virtualenv at ~/.virtualenvs/automobile-web" project-jdk-type="Python SDK" />
 </project>

--- a/advanced_redirects/__init__.py
+++ b/advanced_redirects/__init__.py
@@ -1,2 +1,2 @@
-__author__ = 'Eric Ressler'
-__version__ = '0.9.5'
+__author__ = 'Evgeniy Medvedev'
+__version__ = '0.0.1'

--- a/advanced_redirects/admin.py
+++ b/advanced_redirects/admin.py
@@ -26,13 +26,17 @@ class HasRedirectListFilter(admin.SimpleListFilter):
 
     def lookups(self, request, model_admin):
         return (
-            (False, 'Yes'),
-            (True, 'No')
+            ('1', 'Yes'),
+            ('0', 'No')
         )
 
     def queryset(self, request, queryset):
-        if self.value():
-            return queryset.filter(redirect_to_url__isnull=self.value())
+
+        if self.value() == '1':
+            return queryset.filter(redirect_to_url__isnull=False)
+
+        if self.value() == '0':
+            return queryset.filter(Q(redirect_to_url__isnull=True) | Q(redirect_to_url__exact=''))
 
 
 class ReferralInlineAdmin(admin.TabularInline):

--- a/advanced_redirects/admin.py
+++ b/advanced_redirects/admin.py
@@ -35,7 +35,7 @@ class HasRedirectListFilter(admin.SimpleListFilter):
             return queryset.filter(redirect_to_url__isnull=self.value())
 
 
-class ReferralInlineAdmin (admin.TabularInline):
+class ReferralInlineAdmin(admin.TabularInline):
     """
     Non-editable inline displays the referrals information.
     """
@@ -49,7 +49,8 @@ class ReferralInlineAdmin (admin.TabularInline):
         return ['referer_url', 'hits', 'last_hit']
 
 
-class RedirectAdmin (admin.ModelAdmin):
+@admin.register(Redirect)
+class RedirectAdmin(admin.ModelAdmin):
     """
     The main admin functionality for the Redirects model. Slightly customized.
     """
@@ -58,11 +59,17 @@ class RedirectAdmin (admin.ModelAdmin):
 
     form = RedirectAdminForm
     fields = ('originating_url', 'redirect_to_url', 'redirect_type',)
-    list_display = ('originating_url', 'redirect_to_url', 'redirect_type',)
+    list_display = ('get_originating_url', 'redirect_to_url', 'redirect_type', 'get_hits')
     list_editable = ('redirect_to_url', 'redirect_type')
     list_filter = (HasRedirectListFilter,)
     search_fields = ('originating_url', 'redirect_to_url')
     inlines = (ReferralInlineAdmin,)
     actions = [delete_referers, reset_referer_hit_counts]
 
-admin.site.register(Redirect, RedirectAdmin)
+    def get_originating_url(self, obj):
+        return "%s" % obj.originating_url[:100]
+    get_originating_url.short_description = 'URL'
+
+    def get_hits(self, obj):
+        """Return referrals quantity for the instance."""
+        return sum(obj.referrals.all().values_list('hits', flat=True))

--- a/advanced_redirects/management/__init__.py
+++ b/advanced_redirects/management/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'emedvedev'

--- a/advanced_redirects/management/commands/__init__.py
+++ b/advanced_redirects/management/commands/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'emedvedev'

--- a/advanced_redirects/management/commands/update_redirects_hash.py
+++ b/advanced_redirects/management/commands/update_redirects_hash.py
@@ -1,0 +1,22 @@
+import hashlib
+
+from django.core.management import BaseCommand
+
+from advanced_redirects.models import Redirect
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        for item in Redirect.objects.all().iterator():
+            new_id = hashlib.sha256(item.originating_url.encode('utf-8')).hexdigest()
+            print 'id:', item.id, '(', new_id, ')'
+
+            Redirect.objects.filter(id=item.id).update(id=new_id)
+
+        # string_val = "x" * 300
+        # r1 = Redirect(originating_url=string_val + '1')
+        # r1.save()
+        #
+        # r2 = Redirect(originating_url=string_val + '2')
+        # r2.save()

--- a/advanced_redirects/management/commands/update_redirects_hash.py
+++ b/advanced_redirects/management/commands/update_redirects_hash.py
@@ -2,17 +2,17 @@ import hashlib
 
 from django.core.management import BaseCommand
 
-from advanced_redirects.models import Redirect
+from advanced_redirects.models import Redirect, Referral
 
 
 class Command(BaseCommand):
 
     def handle(self, *args, **options):
         for item in Redirect.objects.all().iterator():
-            new_id = hashlib.sha256(item.originating_url.encode('utf-8')).hexdigest()
-            print 'id:', item.id, '(', new_id, ')'
+            item.url_hash = hashlib.sha256(item.originating_url.encode('utf-8')).hexdigest()
+            item.save()
+            print 'id:', item.id, '(', item.url_hash, ')'
 
-            Redirect.objects.filter(id=item.id).update(id=new_id)
 
         # string_val = "x" * 300
         # r1 = Redirect(originating_url=string_val + '1')

--- a/advanced_redirects/middleware.py
+++ b/advanced_redirects/middleware.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import re
 
@@ -57,13 +58,15 @@ class AdvancedRedirectMiddleware(object):
             return response
 
         full_path = request.get_full_path()
+        url_hash = hashlib.sha256(full_path.encode('utf-8')).hexdigest()
+
         redirect = None
 
         logger.debug('full_path = %s', full_path)
 
         # check to see if there is an existing redirect for the full path as is
         try:
-            redirect = Redirect.objects.get(originating_url=full_path)
+            redirect = Redirect.objects.get(id=url_hash)
         except Redirect.DoesNotExist:
             pass
 
@@ -72,9 +75,10 @@ class AdvancedRedirectMiddleware(object):
             # This scenario should never be reached because CommonMiddleware adds the slash beforehand
             path_len = len(request.path)
             full_path = full_path[:path_len] + '/' + full_path[path_len:]
+            url_hash = hashlib.sha256(full_path.encode('utf-8')).hexdigest()
 
             try:
-                redirect = Redirect.objects.get(originating_url=full_path)
+                redirect = Redirect.objects.get(id=url_hash)
             except Redirect.DoesNotExist:
                 pass
 
@@ -82,8 +86,10 @@ class AdvancedRedirectMiddleware(object):
         if not redirect and request.path.endswith('/'):
             # try removing the trailing slash to see if a redirect is found
             full_path = request.path[:-1]
+            url_hash = hashlib.sha256(full_path.encode('utf-8')).hexdigest()
+
             try:
-                redirect = Redirect.objects.get(originating_url=full_path)
+                redirect = Redirect.objects.get(id=url_hash)
             except Redirect.DoesNotExist:
                 pass
 
@@ -109,6 +115,9 @@ class AdvancedRedirectMiddleware(object):
         if redirect.redirect_to_url:
             response_class = self.get_response_class(redirect)
             return response_class(redirect.redirect_to_url)
+
+        if redirect.redirect_type == redirect_settings.GONE_REDIRECT_VALUE:
+            return http.HttpResponseGone('The requested resource is no longer available at the server and no forwarding address is known.')
 
         # show the 404 page
         return response

--- a/advanced_redirects/middleware.py
+++ b/advanced_redirects/middleware.py
@@ -66,7 +66,7 @@ class AdvancedRedirectMiddleware(object):
 
         # check to see if there is an existing redirect for the full path as is
         try:
-            redirect = Redirect.objects.get(id=url_hash)
+            redirect = Redirect.objects.get(url_hash=url_hash)
         except Redirect.DoesNotExist:
             pass
 
@@ -78,7 +78,7 @@ class AdvancedRedirectMiddleware(object):
             url_hash = hashlib.sha256(full_path.encode('utf-8')).hexdigest()
 
             try:
-                redirect = Redirect.objects.get(id=url_hash)
+                redirect = Redirect.objects.get(url_hash=url_hash)
             except Redirect.DoesNotExist:
                 pass
 
@@ -89,7 +89,7 @@ class AdvancedRedirectMiddleware(object):
             url_hash = hashlib.sha256(full_path.encode('utf-8')).hexdigest()
 
             try:
-                redirect = Redirect.objects.get(id=url_hash)
+                redirect = Redirect.objects.get(url_hash=url_hash)
             except Redirect.DoesNotExist:
                 pass
 

--- a/advanced_redirects/migrations/0002_auto_20150817_0545.py
+++ b/advanced_redirects/migrations/0002_auto_20150817_0545.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('advanced_redirects', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='redirect',
+            options={'ordering': ('originating_url',), 'verbose_name': 'redirect', 'verbose_name_plural': 'redirects'},
+        ),
+        migrations.AlterField(
+            model_name='redirect',
+            name='id',
+            field=models.CharField(max_length=129, serialize=False, primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='redirect',
+            name='originating_url',
+            field=models.CharField(help_text=b'The originating URL that triggered a 404 error or is manually entered.', max_length=255),
+        ),
+    ]

--- a/advanced_redirects/migrations/0002_auto_20150818_0810.py
+++ b/advanced_redirects/migrations/0002_auto_20150818_0810.py
@@ -15,14 +15,19 @@ class Migration(migrations.Migration):
             name='redirect',
             options={'ordering': ('originating_url',), 'verbose_name': 'redirect', 'verbose_name_plural': 'redirects'},
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='redirect',
-            name='id',
-            field=models.CharField(max_length=129, serialize=False, primary_key=True),
+            name='url_hash',
+            field=models.CharField(max_length=129, unique=True, null=True),
         ),
         migrations.AlterField(
             model_name='redirect',
             name='originating_url',
             field=models.CharField(help_text=b'The originating URL that triggered a 404 error or is manually entered.', max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='redirect',
+            name='redirect_type',
+            field=models.CharField(default=b'301', max_length=10, choices=[(b'301', b'301 - Permanent'), (b'302', b'302 - Temporary'), (b'410', b'410 - Gone')]),
         ),
     ]

--- a/advanced_redirects/models.py
+++ b/advanced_redirects/models.py
@@ -15,7 +15,7 @@ class Redirect(models.Model):
         verbose_name = _('redirect')
         verbose_name_plural = _('redirects')
 
-    id = models.CharField(max_length=129, primary_key=True, editable=True)
+    url_hash = models.CharField(max_length=129, unique=True, null=True)
     originating_url = models.CharField(
         max_length=255,
         help_text='The originating URL that triggered a 404 error or is manually entered.'
@@ -37,11 +37,11 @@ class Redirect(models.Model):
 
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         self.originating_url = smart_text(self.originating_url)
-        self.id = hashlib.sha256(self.originating_url.encode('utf-8')).hexdigest()
+        self.url_hash = hashlib.sha256(self.originating_url.encode('utf-8')).hexdigest()
         super(Redirect, self).save(force_insert, force_update, using, update_fields)
 
 
-class Referral (models.Model):
+class Referral(models.Model):
     """
     Stores the referer from the request headers that directed to the url that generated a 404 error.
     This can be useful for identifying who is linking to pages that do not exist.

--- a/advanced_redirects/models.py
+++ b/advanced_redirects/models.py
@@ -32,8 +32,12 @@ class Redirect(models.Model):
         default=settings.REDIRECT_CHOICES[0][0]
     )
 
-    def __str__(self):
-        return "%s ---> %s" % (self.originating_url[:50], self.redirect_to_url)
+    def __unicode__(self):
+        try:
+            ret = "%s ---> %s" % (self.originating_url[:50], self.redirect_to_url)
+        except UnicodeEncodeError:
+            ret = self.url_hash
+        return ret
 
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         self.originating_url = smart_text(self.originating_url)
@@ -71,3 +75,6 @@ class Referral(models.Model):
         self.hits = 0
         self.last_hit = None
         self.save()
+
+    def __unicode__(self):
+        return '%d' % self.id

--- a/advanced_redirects/settings.py
+++ b/advanced_redirects/settings.py
@@ -13,3 +13,8 @@ REFERER_NONE_VALUE = '(no referer)'
 
 # Optional setting to specify default redirection for 404 hits if no explicit redirect is provided
 DEFAULT_404_REDIRECT = getattr(settings, 'DEFAULT_404_REDIRECT', None)
+
+# Optional setting to check urls pattern
+URL_MATCH = getattr(settings, 'REDIRECT_URL_MATCH', False)
+
+URL_MATCH_OPTIONS = getattr(settings, 'REDIRECT_URL_MATCH_OPTIONS', {})

--- a/advanced_redirects/settings.py
+++ b/advanced_redirects/settings.py
@@ -3,9 +3,12 @@ from django.conf import settings
 # Options for options list in admin page
 PERMANENT_REDIRECT_VALUE = '301'
 TEMPORARY_REDIRECT_VALUE = '302'
+GONE_REDIRECT_VALUE = '410'
+
 REDIRECT_CHOICES = (
     (PERMANENT_REDIRECT_VALUE, '301 - Permanent'),
-    (TEMPORARY_REDIRECT_VALUE, '302 - Temporary')
+    (TEMPORARY_REDIRECT_VALUE, '302 - Temporary'),
+    (GONE_REDIRECT_VALUE, '410 - Gone')
 )
 
 # default string name to use for 404s that don't provide a referer value in the request headers

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [metadata]
 description-file = README.md
+
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,29 @@
-from distutils.core import setup
+import os
+
+from setuptools import find_packages, setup
 
 VERSION = __import__("advanced_redirects").__version__
 
+with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
+    README = readme.read()
+
+# allow setup.py to be run from any path
+os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+
 setup(
-    name='django-advanced-redirects',
-    packages=['advanced_redirects'],
+    name='ws-advanced-redirects',
     version=VERSION,
-    description='Advanced redirect management for Django applications.',
-    author='Eric Ressler',
-    author_email='eric@ericressler.com',
-    url='http://eressler.github.io/django-advanced-redirects/',
-    download_url="https://github.com/eressler/django-advanced-redirects/tarball/{0}".format(VERSION),
-    keywords=['django', 'redirects', 'seo'],
-    classifiers=[],
-    install_requires=[
-        'django>=1.7.4'
-    ]
+    packages=find_packages(),
+    include_package_data=True,
+    description='Advanced redirect management for wheel-size site.',
+    long_description=README,
+    url='https://github.com/sorlandet/django-advanced-redirects/',
+    author='Evgeniy Medvedev',
+    author_email='yevgeniy.medvedev@gmail.com',
+    classifiers=[
+        'Framework :: Django :: 1.8',  # replace "X.Y" as appropriate
+        'Intended Audience :: Wheel-Size Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+    ],
 )


### PR DESCRIPTION
this is last chance resourt to take some url processing
Ex.
REDIRECT_URL_MATCH = True
REDIRECT_URL_MATCH_OPTIONS = {
    'pattern': '^/size/(?P<make>[\w-]+)/(?P<model>[\w-]+)/(?P<year>\d{4})/$',
    'placeholder': '/size/%(make)s/%(model)s/',
    'field': 'year'
}

this gives an oportunity to set in admin such redirect rule: /size/some-make/some-incorrect-model/  --> /size/some-make/some-correct-model/
and to pass correctly for /size/some-make/some-incorrect-model/{year} --> /size/some-make/some-correct-model/{year}
